### PR TITLE
add PyQt5/PyQt6 enum compatibility for QGIS v3/v4 support

### DIFF
--- a/location_service/location_service.py
+++ b/location_service/location_service.py
@@ -11,6 +11,11 @@ from .ui.places.places import PlacesUi
 from .ui.routes.routes import RoutesUi
 from .ui.terms.terms import TermsUi
 
+try:
+    _WindowStaysOnTopHint = Qt.WindowStaysOnTopHint
+except AttributeError:
+    _WindowStaysOnTopHint = Qt.WindowType.WindowStaysOnTopHint
+
 
 class LocationService:
     """
@@ -114,28 +119,28 @@ class LocationService:
         """
         Displays the configuration dialog window.
         """
-        self.config.setWindowFlags(Qt.WindowStaysOnTopHint)  # type: ignore
+        self.config.setWindowFlags(_WindowStaysOnTopHint)  # type: ignore
         self.config.show()
 
     def show_maps(self) -> None:
         """
         Displays the maps dialog window.
         """
-        self.maps.setWindowFlags(Qt.WindowStaysOnTopHint)  # type: ignore
+        self.maps.setWindowFlags(_WindowStaysOnTopHint)  # type: ignore
         self.maps.show()
 
     def show_places(self) -> None:
         """
         Displays the places dialog window.
         """
-        self.places.setWindowFlags(Qt.WindowStaysOnTopHint)  # type: ignore
+        self.places.setWindowFlags(_WindowStaysOnTopHint)  # type: ignore
         self.places.show()
 
     def show_routes(self) -> None:
         """
         Displays the routes dialog window.
         """
-        self.routes.setWindowFlags(Qt.WindowStaysOnTopHint)  # type: ignore
+        self.routes.setWindowFlags(_WindowStaysOnTopHint)  # type: ignore
         self.routes.show()
 
     def show_terms(self) -> None:

--- a/location_service/metadata.txt
+++ b/location_service/metadata.txt
@@ -4,7 +4,7 @@ description=QGIS Plugin for Amazon Location Service
 about=This plugin uses the functionality of Amazon Location Service in QGIS.
 qgisMinimumVersion=3.34
 qgisMaximumVersion=4.99
-version=4.1.0
+version=4.1.1
 supportsQt6=True
 
 #Plugin main icon

--- a/location_service/utils/external_api_handler.py
+++ b/location_service/utils/external_api_handler.py
@@ -7,6 +7,16 @@ from qgis.core import QgsNetworkAccessManager
 from qgis.PyQt.QtCore import QEventLoop, QUrl
 from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 
+try:
+    _ContentTypeHeader = QNetworkRequest.ContentTypeHeader
+except AttributeError:
+    _ContentTypeHeader = QNetworkRequest.KnownHeaders.ContentTypeHeader
+
+try:
+    _NoError = QNetworkReply.NoError
+except AttributeError:
+    _NoError = QNetworkReply.NetworkError.NoError
+
 
 class ExternalApiHandler:
     """
@@ -38,7 +48,7 @@ class ExternalApiHandler:
             if an error occurs.
         """
         request = QNetworkRequest(QUrl(url))
-        request.setHeader(QNetworkRequest.ContentTypeHeader, self.JSON_CONTENT_TYPE)
+        request.setHeader(_ContentTypeHeader, self.JSON_CONTENT_TYPE)
         encoded_data = json.dumps(data).encode(self.UTF8_ENCODING)
         event_loop = QEventLoop()
         reply = self.network_manager.post(request, encoded_data)
@@ -62,7 +72,7 @@ class ExternalApiHandler:
             as JSON.
         """
         try:
-            if reply.error() == QNetworkReply.NoError:  # type: ignore
+            if reply.error() == _NoError:  # type: ignore
                 response_data = reply.readAll().data().decode(self.UTF8_ENCODING)
                 return json.loads(response_data)
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qgis-amazonlocationservice-plugin"
-version = "4.0.0"
+version = "4.1.1"
 description = "QGIS Plugin for Amazon Location Service"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- Add try/except fallback for Qt.WindowStaysOnTopHint → Qt.WindowType.WindowStaysOnTopHint in location_service.py
- Add try/except fallback for QNetworkRequest.ContentTypeHeader → QNetworkRequest.KnownHeaders.ContentTypeHeader in external_api_handler.py
- Add try/except fallback for QNetworkReply.NoError → QNetworkReply.NetworkError.NoError in external_api_handler.py

### Notes
<!-- If manual testing is required, please describe the procedure. -->

