### PR TITLE
Feat/maps v2 style descriptor options

### DIFF
--- a/location_service/functions/maps.py
+++ b/location_service/functions/maps.py
@@ -130,10 +130,6 @@ class MapsFunctions:
         try:
             region_value, apikey_value = self.get_configuration_settings()
             tile_url = self.build_tile_url(region_value, apikey_value, options)
-            # {z}/{x}/{y} placeholders must remain unencoded for QGIS to
-            # substitute them. ',' is preserved so travelModes (e.g.
-            # "Transit,Truck") is not double-encoded, and '%' is preserved
-            # so existing percent-encoded query values are not encoded again.
             encoded_tile_url = quote(tile_url, safe=":/?{}=,%")
             layer_url = f"type=xyz&url={encoded_tile_url}&zmin=0&zmax=18"
             layer_name = self.compose_layer_name(options)

--- a/location_service/functions/maps.py
+++ b/location_service/functions/maps.py
@@ -46,9 +46,18 @@ class MapsFunctions:
 
         Returns:
             tuple[str, str]: A tuple containing the region and API key.
+
+        Raises:
+            ValueError: If the region or API key is missing or empty.
         """
         region = self.configuration_handler.get_setting(self.KEY_REGION)
         apikey = self.configuration_handler.get_setting(self.KEY_APIKEY)
+
+        if not region or not str(region).strip():
+            raise ValueError("Missing required configuration setting: region")
+        if not apikey or not str(apikey).strip():
+            raise ValueError("Missing required configuration setting: apikey")
+
         return region, apikey
 
     def build_tile_url(self, region: str, apikey: str, options: MapsOptions) -> str:

--- a/location_service/functions/maps.py
+++ b/location_service/functions/maps.py
@@ -1,20 +1,42 @@
+from dataclasses import dataclass, field
+from urllib.parse import quote, urlencode
+
 from qgis.core import QgsProject, QgsRasterLayer
 
 from ..utils.configuration_handler import ConfigurationHandler
 
 
+@dataclass
+class MapsOptions:
+    """
+    Holds the user-selected map style options that map to Amazon Location
+    Service Maps V2 style and tile parameters.
+    """
+
+    style: str
+    color_scheme: str = "Light"
+    language: str = ""
+    political_view: str = ""
+    terrain: str = ""
+    contour_density: str = ""
+    traffic: str = ""
+    travel_modes: list[str] = field(default_factory=list)
+    buildings_3d: bool = False
+
+
 class MapsFunctions:
     """
-    Manages the loading of vector tile layers into a QGIS project
+    Manages the loading of XYZ tile (raster) layers into a QGIS project
     based on configurations.
     """
 
     KEY_REGION = "region_value"
     KEY_APIKEY = "apikey_value"
+    BASE_URL = "https://als.dayjournal.dev"
 
     def __init__(self) -> None:
         """
-        Initializes the MapFunctions with a configuration handler.
+        Initializes the MapsFunctions with a configuration handler.
         """
         self.configuration_handler = ConfigurationHandler()
 
@@ -23,28 +45,91 @@ class MapsFunctions:
         Fetches necessary configuration settings from the settings manager.
 
         Returns:
-            Tuple[str, str]: A tuple containing the region,
-            maps name, and API key.
+            tuple[str, str]: A tuple containing the region and API key.
         """
         region = self.configuration_handler.get_setting(self.KEY_REGION)
         apikey = self.configuration_handler.get_setting(self.KEY_APIKEY)
         return region, apikey
 
-    def add_xyz_tile_layer(self, selected_style: str) -> str:
+    def build_tile_url(self, region: str, apikey: str, options: MapsOptions) -> str:
+        """
+        Builds the XYZ tile URL with selected style parameters.
+
+        The Lambda wrapper translates the camelCase keys below to Amazon
+        Location Service Maps V2 GetStyleDescriptor parameters (kebab-case).
+
+        Amazon Location Service only accepts ``colorScheme`` for the ``Satellite`` style; the
+        other descriptor parameters (politicalView, terrain, contourDensity,
+        traffic, travelModes, buildings) are therefore omitted when
+        ``style == 'Satellite'``.
+
+        Note:
+            `language` is intentionally never sent. Server-side label language
+            switching is not currently supported by the proxy renderer.
+
+        Args:
+            region (str): Amazon Location Service region value.
+            apikey (str): API key value.
+            options (MapsOptions): User-selected style options.
+
+        Returns:
+            str: The XYZ tile URL with z/x/y placeholders for QGIS.
+        """
+        params: dict[str, str] = {
+            "APIkey": apikey,
+            "colorScheme": options.color_scheme,
+        }
+        if options.style != "Satellite":
+            optional_params = {
+                "politicalView": options.political_view,
+                "terrain": options.terrain,
+                "contourDensity": options.contour_density,
+                "traffic": options.traffic,
+            }
+            for key, value in optional_params.items():
+                if value:
+                    params[key] = value
+            if options.travel_modes:
+                params["travelModes"] = ",".join(options.travel_modes)
+            if options.buildings_3d:
+                params["buildings"] = "Buildings3D"
+        query = urlencode(params, safe=",")
+        return f"{self.BASE_URL}/{region}/{options.style}/{{z}}/{{x}}/{{y}}?{query}"
+
+    def compose_layer_name(self, options: MapsOptions) -> str:
+        """
+        Composes the layer name shown in the QGIS layer panel.
+
+        Args:
+            options (MapsOptions): User-selected style options.
+
+        Returns:
+            str: A short layer name combining style and color scheme.
+        """
+        return f"{options.style} {options.color_scheme}"
+
+    def add_xyz_tile_layer(self, options: MapsOptions) -> None:
         """
         Adds an XYZ tile layer (raster tile) into the current QGIS project using
         configuration settings.
+
+        Args:
+            options (MapsOptions): User-selected style options.
         """
         try:
             region_value, apikey_value = self.get_configuration_settings()
-            tile_url = (
-                f"https://als.dayjournal.dev/{region_value}/{selected_style}/"
-                f"{{z}}/{{x}}/{{y}}?APIkey={apikey_value}"
-            )
-            layer_url = f"type=xyz&url={tile_url}&zmin=0&zmax=18"
-            xyz_tile_layer = QgsRasterLayer(layer_url, selected_style, "wms")
+            tile_url = self.build_tile_url(region_value, apikey_value, options)
+            # {z}/{x}/{y} placeholders must remain unencoded for QGIS to
+            # substitute them. ',' is preserved so travelModes (e.g.
+            # "Transit,Truck") is not double-encoded.
+            encoded_tile_url = quote(tile_url, safe=":/?{}=,")
+            layer_url = f"type=xyz&url={encoded_tile_url}&zmin=0&zmax=18"
+            layer_name = self.compose_layer_name(options)
+            xyz_tile_layer = QgsRasterLayer(layer_url, layer_name, "wms")
+            if not xyz_tile_layer.isValid():
+                raise RuntimeError(f"Invalid XYZ tile layer for URL: {layer_url}")
             QgsProject.instance().addMapLayer(xyz_tile_layer)
         except KeyError as e:
             raise KeyError(f"Missing configuration for {e!r}") from e
         except Exception as e:
-            raise Exception(f"Failed to load XYZ tile layer: {e!r}") from e
+            raise RuntimeError(f"Failed to add XYZ tile layer: {e!r}") from e

--- a/location_service/functions/maps.py
+++ b/location_service/functions/maps.py
@@ -63,9 +63,9 @@ class MapsFunctions:
         traffic, travelModes, buildings) are therefore omitted when
         ``style == 'Satellite'``.
 
-        Note:
-            `language` is intentionally never sent. Server-side label language
-            switching is not currently supported by the proxy renderer.
+        The ``language`` parameter is consumed by the proxy wrapper (not by AWS).
+        The wrapper rewrites the style descriptor's ``text-field`` expressions to
+        ``name:{language}`` before chiitiler renders the tile.
 
         Args:
             region (str): Amazon Location Service region value.
@@ -89,6 +89,8 @@ class MapsFunctions:
             for key, value in optional_params.items():
                 if value:
                     params[key] = value
+            if options.language and options.language != "Default":
+                params["language"] = options.language
             if options.travel_modes:
                 params["travelModes"] = ",".join(options.travel_modes)
             if options.buildings_3d:

--- a/location_service/functions/maps.py
+++ b/location_service/functions/maps.py
@@ -123,8 +123,9 @@ class MapsFunctions:
             tile_url = self.build_tile_url(region_value, apikey_value, options)
             # {z}/{x}/{y} placeholders must remain unencoded for QGIS to
             # substitute them. ',' is preserved so travelModes (e.g.
-            # "Transit,Truck") is not double-encoded.
-            encoded_tile_url = quote(tile_url, safe=":/?{}=,")
+            # "Transit,Truck") is not double-encoded, and '%' is preserved
+            # so existing percent-encoded query values are not encoded again.
+            encoded_tile_url = quote(tile_url, safe=":/?{}=,%")
             layer_url = f"type=xyz&url={encoded_tile_url}&zmin=0&zmax=18"
             layer_name = self.compose_layer_name(options)
             xyz_tile_layer = QgsRasterLayer(layer_url, layer_name, "wms")

--- a/location_service/metadata.txt
+++ b/location_service/metadata.txt
@@ -4,8 +4,7 @@ description=QGIS Plugin for Amazon Location Service
 about=This plugin uses the functionality of Amazon Location Service in QGIS.
 qgisMinimumVersion=3.34
 qgisMaximumVersion=4.99
-version=4.1.2
-supportsQt6=True
+version=4.2.0
 
 #Plugin main icon
 icon=ui/icon.png

--- a/location_service/ui/checkmark.svg
+++ b/location_service/ui/checkmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M3 8l3.5 3.5L13 5" stroke="#FFFFFF" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/location_service/ui/maps/constants.py
+++ b/location_service/ui/maps/constants.py
@@ -1,0 +1,148 @@
+MAP_STYLES = ("Standard", "Monochrome", "Hybrid", "Satellite")
+COLOR_SCHEMES = ("Light", "Dark")
+LANGUAGES = (
+    "Default",
+    "ar",
+    "as",
+    "az",
+    "be",
+    "bg",
+    "bn",
+    "bs",
+    "ca",
+    "cs",
+    "cy",
+    "da",
+    "de",
+    "el",
+    "en",
+    "es",
+    "et",
+    "eu",
+    "fi",
+    "fo",
+    "fr",
+    "ga",
+    "gl",
+    "gn",
+    "gu",
+    "he",
+    "hi",
+    "hr",
+    "hu",
+    "hy",
+    "id",
+    "is",
+    "it",
+    "ja",
+    "ka",
+    "kk",
+    "km",
+    "kn",
+    "ko",
+    "ky",
+    "lt",
+    "lv",
+    "mk",
+    "ml",
+    "mr",
+    "ms",
+    "mt",
+    "my",
+    "nl",
+    "no",
+    "or",
+    "pa",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sk",
+    "sl",
+    "sq",
+    "sr",
+    "sv",
+    "ta",
+    "te",
+    "th",
+    "tr",
+    "uk",
+    "uz",
+    "vi",
+    "zh",
+)
+POLITICAL_VIEWS = (
+    ("Default", ""),
+    ("Argentina (ARG)", "ARG"),
+    ("Egypt (EGY)", "EGY"),
+    ("India (IND)", "IND"),
+    ("Kenya (KEN)", "KEN"),
+    ("Morocco (MAR)", "MAR"),
+    ("Russia (RUS)", "RUS"),
+    ("Sudan (SDN)", "SDN"),
+    ("Serbia (SRB)", "SRB"),
+    ("Suriname (SUR)", "SUR"),
+    ("Syria (SYR)", "SYR"),
+    ("Türkiye (TUR)", "TUR"),
+    ("Tanzania (TZA)", "TZA"),
+    ("Uruguay (URY)", "URY"),
+    ("Vietnam (VNM)", "VNM"),
+)
+CONTOUR_DENSITIES = (
+    ("None", ""),
+    ("Low", "Low"),
+    ("Medium", "Medium"),
+    ("High", "High"),
+)
+TRAFFIC_MODES = (
+    ("None", ""),
+    ("All", "All"),
+    ("Congestion", "Congestion"),
+)
+STYLE_SUPPORT: dict[str, tuple[str, ...]] = {
+    "Standard": (
+        "colorScheme",
+        "language",
+        "politicalView",
+        "terrain_hillshade",
+        "terrain_3d",
+        "contourDensity",
+        "traffic",
+        "travelModes",
+        "buildings",
+    ),
+    "Monochrome": (
+        "colorScheme",
+        "language",
+        "politicalView",
+        "terrain_hillshade",
+        "terrain_3d",
+        "contourDensity",
+        "traffic",
+        "travelModes",
+        "buildings",
+    ),
+    "Hybrid": (
+        "colorScheme",
+        "language",
+        "politicalView",
+        "terrain_3d",
+        "contourDensity",
+        "traffic",
+        "travelModes",
+    ),
+    "Satellite": ("colorScheme", "terrain_3d"),
+}
+RENDERER_UNSUPPORTED = ("language", "terrain_3d", "buildings")
+RENDERER_TOOLTIP_LANGUAGE = (
+    "Label language switching is not currently supported by this plugin. "
+    "The selection has no effect."
+)
+RENDERER_TOOLTIP_BUILDINGS = (
+    "3D Buildings rendering is not currently supported by this plugin."
+)
+RENDERER_TOOLTIP_TERRAIN = (
+    "Terrain3D is not currently supported by this plugin. "
+    "Only Hillshade can be rendered (Standard / Monochrome only)."
+)
+STYLE_TOOLTIP_NOT_SUPPORTED = "This option is not supported by the {style} map style."

--- a/location_service/ui/maps/constants.py
+++ b/location_service/ui/maps/constants.py
@@ -133,11 +133,7 @@ STYLE_SUPPORT: dict[str, tuple[str, ...]] = {
     ),
     "Satellite": ("colorScheme", "terrain_3d"),
 }
-RENDERER_UNSUPPORTED = ("language", "terrain_3d", "buildings")
-RENDERER_TOOLTIP_LANGUAGE = (
-    "Label language switching is not currently supported by this plugin. "
-    "The selection has no effect."
-)
+RENDERER_UNSUPPORTED = ("terrain_3d", "buildings")
 RENDERER_TOOLTIP_BUILDINGS = (
     "3D Buildings rendering is not currently supported by this plugin."
 )

--- a/location_service/ui/maps/maps.py
+++ b/location_service/ui/maps/maps.py
@@ -13,7 +13,6 @@ from .constants import (
     MAP_STYLES,
     POLITICAL_VIEWS,
     RENDERER_TOOLTIP_BUILDINGS,
-    RENDERER_TOOLTIP_LANGUAGE,
     RENDERER_TOOLTIP_TERRAIN,
     RENDERER_UNSUPPORTED,
     STYLE_SUPPORT,
@@ -126,10 +125,11 @@ class MapsUi(QDialog):
             "colorScheme",
         )
 
-        self.language_comboBox.setEnabled(False)
-        self.language_comboBox.setCurrentText("Default")
-        self.language_comboBox.setToolTip(RENDERER_TOOLTIP_LANGUAGE)
-
+        self._apply_combobox_constraint(
+            self.language_comboBox,
+            style,
+            "language",
+        )
         self._apply_combobox_constraint(
             self.political_view_comboBox,
             style,

--- a/location_service/ui/maps/maps.py
+++ b/location_service/ui/maps/maps.py
@@ -1,21 +1,34 @@
 import os
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtWidgets import QDialog, QMessageBox
+from qgis.PyQt.QtWidgets import QComboBox, QDialog, QMessageBox
 
-from ...functions.maps import MapsFunctions
+from ...functions.maps import MapsFunctions, MapsOptions
 from ...utils.configuration_handler import ConfigurationHandler
 from ..style_loader import load_style
+from .constants import (
+    COLOR_SCHEMES,
+    CONTOUR_DENSITIES,
+    LANGUAGES,
+    MAP_STYLES,
+    POLITICAL_VIEWS,
+    RENDERER_TOOLTIP_BUILDINGS,
+    RENDERER_TOOLTIP_LANGUAGE,
+    RENDERER_TOOLTIP_TERRAIN,
+    RENDERER_UNSUPPORTED,
+    STYLE_SUPPORT,
+    STYLE_TOOLTIP_NOT_SUPPORTED,
+    TRAFFIC_MODES,
+)
 
 
 class MapsUi(QDialog):
     """
-    A dialog for managing maps configurations and adding vector tile layers to a
-    QGIS project.
+    A dialog for managing maps configurations and adding XYZ tile (raster)
+    layers to a QGIS project.
     """
 
     UI_PATH = os.path.join(os.path.dirname(__file__), "maps.ui")
-    MAP_STYLES = ("Standard", "Monochrome", "Hybrid", "Satellite")
 
     def __init__(self) -> None:
         """
@@ -26,29 +39,178 @@ class MapsUi(QDialog):
         load_style(self)
         self.button_add.clicked.connect(self._add)
         self.button_cancel.clicked.connect(self._cancel)
+        self.style_comboBox.currentTextChanged.connect(self._on_style_changed)
         self.maps = MapsFunctions()
         self.configuration_handler = ConfigurationHandler()
         self._populate_maps_options()
+        self._on_style_changed(self.style_comboBox.currentText())
 
     def _populate_maps_options(self) -> None:
         """
         Populates the maps options dropdown with available configurations.
+        Terrain items are populated dynamically by ``_on_style_changed``.
         """
-        for style in self.MAP_STYLES:
+        for style in MAP_STYLES:
             self.style_comboBox.addItem(style)
+        for scheme in COLOR_SCHEMES:
+            self.colorscheme_comboBox.addItem(scheme)
+        for lang in LANGUAGES:
+            self.language_comboBox.addItem(lang)
+        for label, code in POLITICAL_VIEWS:
+            self.political_view_comboBox.addItem(label, code)
+        for label, code in CONTOUR_DENSITIES:
+            self.contour_density_comboBox.addItem(label, code)
+        for label, code in TRAFFIC_MODES:
+            self.traffic_comboBox.addItem(label, code)
+
+    def _set_terrain_items(self, items: tuple[tuple[str, str], ...]) -> None:
+        """
+        Replaces the items in the terrain combo box while preserving the
+        current selection if still valid.
+
+        Args:
+            items (tuple[tuple[str, str], ...]): The new set of (label, code) pairs.
+        """
+        current_code = (
+            self.terrain_comboBox.currentData() if self.terrain_comboBox.count() else ""
+        )
+        self.terrain_comboBox.blockSignals(True)
+        self.terrain_comboBox.clear()
+        for label, code in items:
+            self.terrain_comboBox.addItem(label, code)
+        index = self.terrain_comboBox.findData(current_code)
+        self.terrain_comboBox.setCurrentIndex(index if index >= 0 else 0)
+        self.terrain_comboBox.blockSignals(False)
+
+    def _is_feature_active(self, style: str, feature: str) -> bool:
+        """
+        Returns ``True`` when ``feature`` is both supported by the Amazon Location Service Maps V2
+        GetStyleDescriptor matrix for ``style`` and renderable by the
+        chiitiler pipeline.
+        """
+        if feature in RENDERER_UNSUPPORTED:
+            return False
+        return feature in STYLE_SUPPORT.get(style, ())
+
+    def _style_disabled_tooltip(self, style: str) -> str:
+        """Returns the tooltip shown when an option is disabled by the current style."""
+        return STYLE_TOOLTIP_NOT_SUPPORTED.format(style=style)
+
+    def _apply_combobox_constraint(
+        self,
+        combo: QComboBox,
+        style: str,
+        feature: str,
+    ) -> None:
+        """Toggle a combobox based on style support, resetting it when disabled."""
+        enabled = self._is_feature_active(style, feature)
+        combo.setEnabled(enabled)
+        if enabled:
+            combo.setToolTip("")
+        else:
+            combo.setCurrentIndex(0)
+            combo.setToolTip(self._style_disabled_tooltip(style))
+
+    def _on_style_changed(self, style: str) -> None:
+        """
+        Updates UI constraints based on the selected map style following the
+        Amazon Location Service Maps V2 GetStyleDescriptor matrix combined with
+        the chiitiler renderer limitations.
+
+        Args:
+            style (str): The newly selected style name.
+        """
+        self._apply_combobox_constraint(
+            self.colorscheme_comboBox,
+            style,
+            "colorScheme",
+        )
+
+        self.language_comboBox.setEnabled(False)
+        self.language_comboBox.setCurrentText("Default")
+        self.language_comboBox.setToolTip(RENDERER_TOOLTIP_LANGUAGE)
+
+        self._apply_combobox_constraint(
+            self.political_view_comboBox,
+            style,
+            "politicalView",
+        )
+        self._apply_combobox_constraint(
+            self.contour_density_comboBox,
+            style,
+            "contourDensity",
+        )
+        self._apply_combobox_constraint(
+            self.traffic_comboBox,
+            style,
+            "traffic",
+        )
+
+        travel_modes_enabled = self._is_feature_active(style, "travelModes")
+        self.transit_checkBox.setEnabled(travel_modes_enabled)
+        self.truck_checkBox.setEnabled(travel_modes_enabled)
+        if travel_modes_enabled:
+            self.transit_checkBox.setToolTip("")
+            self.truck_checkBox.setToolTip("")
+        else:
+            self.transit_checkBox.setChecked(False)
+            self.truck_checkBox.setChecked(False)
+            disabled_tip = self._style_disabled_tooltip(style)
+            self.transit_checkBox.setToolTip(disabled_tip)
+            self.truck_checkBox.setToolTip(disabled_tip)
+
+        self.buildings3d_checkBox.setEnabled(False)
+        self.buildings3d_checkBox.setChecked(False)
+        self.buildings3d_checkBox.setToolTip(RENDERER_TOOLTIP_BUILDINGS)
+
+        terrain_items: list[tuple[str, str]] = [("None", "")]
+        if self._is_feature_active(style, "terrain_hillshade"):
+            terrain_items.append(("Hillshade", "Hillshade"))
+        self._set_terrain_items(tuple(terrain_items))
+        self.terrain_comboBox.setEnabled(len(terrain_items) > 1)
+        self.terrain_comboBox.setToolTip(RENDERER_TOOLTIP_TERRAIN)
+
+    def _selected_travel_modes(self) -> list[str]:
+        """
+        Collects the checked travel modes.
+
+        Returns:
+            list[str]: The selected travel mode names.
+        """
+        modes: list[str] = []
+        if self.transit_checkBox.isChecked():
+            modes.append("Transit")
+        if self.truck_checkBox.isChecked():
+            modes.append("Truck")
+        return modes
 
     def _add(self) -> None:
         """
-        Adds the selected vector tile layer to the QGIS project and closes the dialog.
+        Adds the selected XYZ tile (raster) layer to the QGIS project and closes the dialog.
         """
         try:
-            select_style = self.style_comboBox.currentText()
-            self.maps.add_xyz_tile_layer(select_style)
-            self.close()
-        except Exception as e:
-            QMessageBox.critical(
-                self, "Error", f"Failed to add raster tile layer: {e!r}"
+            options = MapsOptions(
+                style=self.style_comboBox.currentText(),
+                color_scheme=self.colorscheme_comboBox.currentText(),
+                language=self.language_comboBox.currentText(),
+                political_view=self.political_view_comboBox.currentData() or "",
+                terrain=self.terrain_comboBox.currentData() or "",
+                contour_density=self.contour_density_comboBox.currentData() or "",
+                traffic=self.traffic_comboBox.currentData() or "",
+                travel_modes=self._selected_travel_modes(),
+                buildings_3d=self.buildings3d_checkBox.isChecked(),
             )
+            self.maps.add_xyz_tile_layer(options)
+            self.close()
+        except KeyError as e:
+            QMessageBox.warning(
+                self,
+                "Configuration Error",
+                f"Required configuration is missing: {e}. "
+                "Please check your API key and region in the settings.",
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to add XYZ tile layer: {e!r}")
 
     def _cancel(self) -> None:
         """

--- a/location_service/ui/maps/maps.ui
+++ b/location_service/ui/maps/maps.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>358</width>
-    <height>166</height>
+    <width>400</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>240</width>
+    <width>320</width>
     <height>0</height>
    </size>
   </property>
@@ -34,29 +34,204 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string/>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="style_label">
-        <property name="text">
-         <string>Style Name</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="style_comboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <widget class="QWidget" name="scrollAreaContents">
+      <layout class="QVBoxLayout" name="scrollLayout">
+       <item>
+        <widget class="QGroupBox" name="basic_groupBox">
+         <property name="title">
+          <string>Basic</string>
+         </property>
+         <layout class="QGridLayout" name="basicLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="style_label">
+            <property name="text">
+             <string>Style Name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="style_comboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="colorscheme_label">
+            <property name="text">
+             <string>Color Scheme</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="colorscheme_comboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="language_label">
+            <property name="text">
+             <string>Language</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="language_comboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="political_view_label">
+            <property name="text">
+             <string>Political View</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="political_view_comboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="topography_groupBox">
+         <property name="title">
+          <string>Topography</string>
+         </property>
+         <layout class="QGridLayout" name="topographyLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="terrain_label">
+            <property name="text">
+             <string>Terrain</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="terrain_comboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="contour_density_label">
+            <property name="text">
+             <string>Contour Density</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="contour_density_comboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="navigation_groupBox">
+         <property name="title">
+          <string>Navigation</string>
+         </property>
+         <layout class="QGridLayout" name="navigationLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="traffic_label">
+            <property name="text">
+             <string>Traffic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="traffic_comboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="travel_modes_label">
+            <property name="text">
+             <string>Travel Modes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="travelModesLayout">
+            <item>
+             <widget class="QCheckBox" name="transit_checkBox">
+              <property name="text">
+               <string>Transit</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="truck_checkBox">
+              <property name="text">
+               <string>Truck</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="features_groupBox">
+         <property name="title">
+          <string>3D Features</string>
+         </property>
+         <layout class="QVBoxLayout" name="featuresLayout">
+          <item>
+           <widget class="QCheckBox" name="buildings3d_checkBox">
+            <property name="text">
+             <string>Buildings3D</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/location_service/ui/style.qss
+++ b/location_service/ui/style.qss
@@ -103,6 +103,43 @@ QComboBox QAbstractItemView {
     padding: 4px;
 }
 
+QComboBox:disabled {
+    background-color: #F2F3F3;
+    color: #687078;
+    border: 1px solid #D5DBDB;
+}
+
+/* --- Scroll Area --- */
+QScrollArea {
+    background-color: transparent;
+    border: none;
+}
+
+QScrollArea > QWidget > QWidget {
+    background-color: transparent;
+}
+
+QScrollBar:vertical {
+    background: #F5F7FA;
+    width: 10px;
+    margin: 0;
+}
+
+QScrollBar::handle:vertical {
+    background: #D5DBDB;
+    border-radius: 4px;
+    min-height: 24px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background: #879596;
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical {
+    height: 0;
+}
+
 /* --- Primary Buttons (Save, Add, Search) --- */
 QPushButton#button_save,
 QPushButton#button_add,
@@ -175,6 +212,41 @@ QPushButton#button_cancel:hover {
 
 QPushButton#button_cancel:pressed {
     background-color: #EAEDED;
+}
+
+/* --- Check Box --- */
+QCheckBox {
+    color: #16191F;
+    font-size: 13px;
+    spacing: 6px;
+    margin-top: 6px;
+}
+
+QCheckBox::indicator {
+    width: 16px;
+    height: 16px;
+    border: 1px solid #D5DBDB;
+    border-radius: 3px;
+    background-color: #FFFFFF;
+}
+
+QCheckBox::indicator:hover {
+    border: 1px solid #879596;
+}
+
+QCheckBox::indicator:checked {
+    background-color: #FF9900;
+    border: 1px solid #EC7211;
+    image: url(${CHECKMARK_PATH});
+}
+
+QCheckBox:disabled {
+    color: #687078;
+}
+
+QCheckBox::indicator:disabled {
+    background-color: #F2F3F3;
+    border: 1px solid #D5DBDB;
 }
 
 /* --- Message Box --- */

--- a/location_service/ui/style_loader.py
+++ b/location_service/ui/style_loader.py
@@ -3,7 +3,9 @@ import os
 from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtWidgets import QWidget
 
-STYLE_PATH = os.path.join(os.path.dirname(__file__), "style.qss")
+_UI_DIR = os.path.dirname(__file__)
+STYLE_PATH = os.path.join(_UI_DIR, "style.qss")
+CHECKMARK_PATH = os.path.join(_UI_DIR, "checkmark.svg").replace("\\", "/")
 
 
 def load_style(widget: QWidget) -> None:
@@ -15,7 +17,8 @@ def load_style(widget: QWidget) -> None:
     """
     try:
         with open(STYLE_PATH, encoding="utf-8") as f:
-            widget.setStyleSheet(f.read())
+            qss = f.read().replace("${CHECKMARK_PATH}", CHECKMARK_PATH)
+            widget.setStyleSheet(qss)
     except (OSError, UnicodeDecodeError) as e:
         QgsMessageLog.logMessage(
             f"Failed to load style: {e!r}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qgis-amazonlocationservice-plugin"
-version = "4.1.2"
+version = "4.2.0"
 description = "QGIS Plugin for Amazon Location Service"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "qgis-amazonlocationservice-plugin"
-version = "4.0.0"
+version = "4.2.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #53 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
- Introduce MapsOptions dataclass and expose color scheme, political view, terrain, contour density, traffic, travel modes via the dialog
- Restructure the dialog into a QScrollArea with four QGroupBox sections (Basic / Topography / Navigation / 3D Features)
- Drive UI enable/disable from a per-style support matrix combined with renderer limitations (language and 3D features stay disabled)
- Bump version to 4.2.0 and drop supportsQt6=True (covered by qgisMaximumVersion=4.99)
- enable label language switching via wrapper

### Notes
<!-- If manual testing is required, please describe the procedure. -->

